### PR TITLE
Publish KMM Packages

### DIFF
--- a/.github/workflows/All-publish.yml
+++ b/.github/workflows/All-publish.yml
@@ -8,6 +8,6 @@ jobs:
   call-kmmbridge-publish:
     uses: touchlab/KMMBridgeGithubWorkflow/.github/workflows/faktorybuildbranches.yml@v0.6
     with:
-      publishTask: kmmBridgePublish publishAndroidDebugPublicationToGitHubPackagesRepository publishAndroidReleasePublicationToGitHubPackagesRepository
+      publishTask: kmmBridgePublish publishKotlinMultiplatformPublicationToGitHubPackagesRepository publishAndroidDebugPublicationToGitHubPackagesRepository publishAndroidReleasePublicationToGitHubPackagesRepository
 #    secrets:
 #      PODSPEC_SSH_KEY: ${{ secrets.PODSPEC_SSH_KEY }}


### PR DESCRIPTION
Update the all-publish workflow (which is used to also publish android) to also run `publishKotlinMultiplatformPublication..` This ensures that our android sample which was consuming it builds correctly